### PR TITLE
Cmake hotifx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ build/
 sdkconfig
 
 *.old
+/.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,17 @@ list(APPEND PROJ_COMPS_LIST)
 
 
 #PROJ_COMPS stores the name of the all custom components required by the project
-set(PROJ_COMPS "kernel" "common""mid-tier" "callbacks" "slave" "master" "firmware")
+set(PROJ_COMPS "kernel" "common" "mid-tier" "callbacks" "slave" "master" "firmware")
 
 #Each component directory is in "components/bemesh"
 set(BASE_COMPS_PATH "components/bemesh/")
 
 
 #We build each project component path in the form "components/bemesh/component_name" and store it in PROJ_COMPS_LIST
-foreach(item ${PROJ_COMPS})
-     set(tmp ${BASE_COMPS_PATH}${item})
-     list(APPEND PROJ_COMPS_LIST ${tmp})
-endforeach()
+foreach (item ${PROJ_COMPS})
+    set(tmp ${BASE_COMPS_PATH}${item})
+    list(APPEND PROJ_COMPS_LIST ${tmp})
+endforeach ()
 
 
 #We include the project.cmake which is necessary to run "idf.py build"
@@ -28,7 +28,6 @@ list(APPEND ADDITIONAL_COMPONENTS "$ENV{IDF_PATH}/components/nvs_flash")
 
 
 set(EXTRA_COMPONENT_DIRS ${ADDITIONAL_COMPONENTS} ${PROJ_COMPS_LIST})
-
 
 
 project(esp32_ble_mesh)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-Master branch of be-mesh
+# esp32-ble-mesh
 
-To monitor multiple esp
+After the toolchain is installed correctly (refer to the wiki):
 
-idf.py monitor -p port
+- To build and launch the program on esp: `idf.py flash monitor -p port`
+- To monitor multiple esp: `idf.py monitor -p port` on the new port
 

--- a/components/bemesh/mid-tier/message_handler_v2.cpp
+++ b/components/bemesh/mid-tier/message_handler_v2.cpp
@@ -45,6 +45,9 @@ namespace bemesh {
   ErrStatus MessageHandler::send(MessageHeader* t_h) {
     // write the message size
     std::size_t msg_len=t_h->psize()+MESSAGE_HEADER_DATA_SIZE;
+    // The Serializer will also add an additional byte representing the ID of the message
+    msg_len += 1;
+    
     m_tx_strm.write(reinterpret_cast<char*>(&msg_len), sizeof(std::size_t));
     // write the message
     t_h->serialize(m_tx_strm);

--- a/components/bemesh/mid-tier/message_handler_v2.cpp
+++ b/components/bemesh/mid-tier/message_handler_v2.cpp
@@ -44,7 +44,7 @@ namespace bemesh {
   
   ErrStatus MessageHandler::send(MessageHeader* t_h) {
     // write the message size
-    std::size_t msg_len=1+t_h->psize()+MESSAGE_HEADER_DATA_SIZE;
+    std::size_t msg_len=t_h->psize()+MESSAGE_HEADER_DATA_SIZE;
     m_tx_strm.write(reinterpret_cast<char*>(&msg_len), sizeof(std::size_t));
     // write the message
     t_h->serialize(m_tx_strm);

--- a/components/bemesh/mid-tier/message_handler_v2.cpp
+++ b/components/bemesh/mid-tier/message_handler_v2.cpp
@@ -92,7 +92,9 @@ namespace bemesh {
 	  // remember to implement dtor pls :(
 	  //delete recv_msg;
 	} else {
-	  (*ops->recv_cb)(recv_msg, ops->args);
+	  if(ops->recv_cb) {
+	    (*ops->recv_cb)(recv_msg, ops->args);
+	  }
 	}
       }
       


### PR DESCRIPTION
Hot fix per il warning nella toolchain dovuto a una scrittura sbagliata del file cmakelists.txt

Sono state inoltre aggiunte due tre righe di documentazione che riportano alla wiki e alla toolchain corretta nel README.md ed è stato aggiunto al file .gitignore la cartella di intelj .idea

Ogni altra variazione non dovrebbe essere considerata ed è dovuta al fatto che il branch di partenza era il master